### PR TITLE
Added url decoding for multibyte pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,6 +145,9 @@ function ParsePath(u)
   //https://github.com/jmjuanes/electron-ejs/pull/9
   pname = pname.replace(/\s/g, ' ').replace(/%20/g, ' ');
 
+  //Decode URL
+  pname = decodeURI(pname);
+
   //Return the path name
   return pname;
 }


### PR DESCRIPTION
マルチバイト文字をファイルパスに含む場合に、デコードしていないファイルパスを開こうとしていて
File Not Found エラーが発生していました。